### PR TITLE
Add SystemDot.Hosting.Diagnostics.HealthChecks

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,28 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
         run: |
-          dotnet nuget push ./output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json
+          dotnet nuget push ./SystemDot.HealthChecks/SystemDot.HealthChecks/output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Deploy to NuGet
+name: Publish to NuGet
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'  # Specify your .NET version
+          dotnet-version: '8.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Push to NuGet
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
         run: |
           if [ "${{ github.ref }}" == "refs/heads/main" ]; then
             dotnet nuget push ./output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,5 +30,6 @@ jobs:
       - name: Push to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
+        working-directory: SystemDot.HealthChecks/SystemDot.HealthChecks/output
         run: |
-          dotnet nuget push ./SystemDot.HealthChecks/SystemDot.HealthChecks/output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "*.nupkg" -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,4 +32,4 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         working-directory: output
         run: |
-          dotnet nuget push "*.nupkg" -k NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "*.nupkg" -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,4 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
         run: |
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            dotnet nuget push ./output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json
-          else
-            dotnet nuget push ./output/*.nupkg -k NUGET_APIKEY -s https://www.myget.org/F/preview/api/v3/index.json
-          fi
+          dotnet nuget push ./output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Push to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
-        working-directory: SystemDot.HealthChecks/SystemDot.HealthChecks/output
+        working-directory: output
         run: |
           dotnet nuget push "*.nupkg" -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Deploy to NuGet
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'  # Specify your .NET version
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack ./SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj --configuration Release --no-build --output ./output
+
+      - name: Push to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            dotnet nuget push ./output/*.nupkg -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json
+          else
+            dotnet nuget push ./output/*.nupkg -k NUGET_APIKEY -s https://www.myget.org/F/preview/api/v3/index.json
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,4 +32,4 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
         working-directory: output
         run: |
-          dotnet nuget push "*.nupkg" -k $NUGET_APIKEY -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "*.nupkg" -k NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Push to NuGet
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_APIKEY }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         working-directory: output
         run: |
           dotnet nuget push "*.nupkg" -k NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/SystemDot.HealthChecks.Web.Example/Program.cs
+++ b/SystemDot.HealthChecks.Web.Example/Program.cs
@@ -1,0 +1,47 @@
+using SystemDot.Hosting.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddHealthChecks().AddHealthCheckTcpListener(options => options.Port = 8080);
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+    {
+        var forecast = Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                (
+                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                    Random.Shared.Next(-20, 55),
+                    summaries[Random.Shared.Next(summaries.Length)]
+                ))
+            .ToArray();
+        return forecast;
+    })
+    .WithName("GetWeatherForecast")
+    .WithOpenApi();
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/SystemDot.HealthChecks.Web.Example/Properties/launchSettings.json
+++ b/SystemDot.HealthChecks.Web.Example/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:39311",
+      "sslPort": 44303
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5094",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7111;http://localhost:5094",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/SystemDot.HealthChecks.Web.Example/System.HealthChecks.http
+++ b/SystemDot.HealthChecks.Web.Example/System.HealthChecks.http
@@ -1,0 +1,6 @@
+@System.HealthChecks_HostAddress = http://localhost:5094
+
+GET {{System.HealthChecks_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/SystemDot.HealthChecks.Web.Example/SystemDot.HealthChecks.Web.Example.csproj
+++ b/SystemDot.HealthChecks.Web.Example/SystemDot.HealthChecks.Web.Example.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SystemDot.Hosting.Diagnostics.HealthChecks\SystemDot.Hosting.Diagnostics.HealthChecks.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/SystemDot.HealthChecks.Web.Example/appsettings.Development.json
+++ b/SystemDot.HealthChecks.Web.Example/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/SystemDot.HealthChecks.Web.Example/appsettings.json
+++ b/SystemDot.HealthChecks.Web.Example/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/SystemDot.HealthChecks.WorkerService.Example/Program.cs
+++ b/SystemDot.HealthChecks.WorkerService.Example/Program.cs
@@ -1,0 +1,9 @@
+using SystemDot.HealthChecks.WorkerService.Example;
+using SystemDot.Hosting.Extensions;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+builder.Services.AddHealthChecks().AddHealthCheckTcpListener();
+
+var host = builder.Build();
+host.Run();

--- a/SystemDot.HealthChecks.WorkerService.Example/Properties/launchSettings.json
+++ b/SystemDot.HealthChecks.WorkerService.Example/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "SystemDot.HealthChecks.WorkerService.Example": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/SystemDot.HealthChecks.WorkerService.Example/SystemDot.HealthChecks.WorkerService.Example.csproj
+++ b/SystemDot.HealthChecks.WorkerService.Example/SystemDot.HealthChecks.WorkerService.Example.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>dotnet-SystemDot.HealthChecks.WorkerService.Example-71dca269-3a82-42ce-a1bd-1aba92605773</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SystemDot.Hosting.Diagnostics.HealthChecks\SystemDot.Hosting.Diagnostics.HealthChecks.csproj" />
+    </ItemGroup>
+</Project>

--- a/SystemDot.HealthChecks.WorkerService.Example/Worker.cs
+++ b/SystemDot.HealthChecks.WorkerService.Example/Worker.cs
@@ -1,0 +1,21 @@
+namespace SystemDot.HealthChecks.WorkerService.Example;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Worker executing at: {time}", DateTimeOffset.Now);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogDebug("Worker running at: {time}", DateTimeOffset.Now);
+            await Task.Delay(1000, stoppingToken);
+        }
+    }
+}

--- a/SystemDot.HealthChecks.WorkerService.Example/appsettings.Development.json
+++ b/SystemDot.HealthChecks.WorkerService.Example/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/SystemDot.HealthChecks.WorkerService.Example/appsettings.json
+++ b/SystemDot.HealthChecks.WorkerService.Example/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/SystemDot.HealthChecks.sln
+++ b/SystemDot.HealthChecks.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemDot.HealthChecks.Web.Example", "SystemDot.HealthChecks.Web.Example\SystemDot.HealthChecks.Web.Example.csproj", "{288DB172-B06D-4D3B-8E7D-84C833C9F9E3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemDot.HealthChecks.WorkerService.Example", "SystemDot.HealthChecks.WorkerService.Example\SystemDot.HealthChecks.WorkerService.Example.csproj", "{6A0E9ACF-53FE-4617-A498-3EBF9EE3E702}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemDot.Hosting.Diagnostics.HealthChecks", "SystemDot.Hosting.Diagnostics.HealthChecks\SystemDot.Hosting.Diagnostics.HealthChecks.csproj", "{CC72B526-932F-4D04-AE47-3645B7D41D9A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{288DB172-B06D-4D3B-8E7D-84C833C9F9E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{288DB172-B06D-4D3B-8E7D-84C833C9F9E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{288DB172-B06D-4D3B-8E7D-84C833C9F9E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{288DB172-B06D-4D3B-8E7D-84C833C9F9E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A0E9ACF-53FE-4617-A498-3EBF9EE3E702}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A0E9ACF-53FE-4617-A498-3EBF9EE3E702}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A0E9ACF-53FE-4617-A498-3EBF9EE3E702}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A0E9ACF-53FE-4617-A498-3EBF9EE3E702}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC72B526-932F-4D04-AE47-3645B7D41D9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC72B526-932F-4D04-AE47-3645B7D41D9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC72B526-932F-4D04-AE47-3645B7D41D9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC72B526-932F-4D04-AE47-3645B7D41D9A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/SystemDot.Hosting.Diagnostics.HealthChecks/HealthCheckTcpListenerBackgroundService.cs
+++ b/SystemDot.Hosting.Diagnostics.HealthChecks/HealthCheckTcpListenerBackgroundService.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SystemDot.Hosting.Extensions;
+
+public sealed class HealthCheckTcpListenerBackgroundService : BackgroundService
+{
+    private readonly HealthCheckService _healthCheckService;
+    private readonly TcpListener _tcpListener;
+    private readonly HealthCheckTcpListenerOptions _options;
+    private readonly ILogger<HealthCheckTcpListenerBackgroundService> _logger;
+
+    public HealthCheckTcpListenerBackgroundService(
+        HealthCheckService healthCheckService,
+        HealthCheckTcpListenerOptions options,
+        ILogger<HealthCheckTcpListenerBackgroundService> logger)
+    {
+        _healthCheckService = healthCheckService ?? throw new ArgumentNullException(nameof(healthCheckService));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _tcpListener = new TcpListener(IPAddress.Any, _options.Port);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Health Check Tcp Listener starting.");
+        
+        await Task.Yield();
+        _tcpListener.Start();
+        
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await CheckHealthReportAsync(stoppingToken);
+            Thread.Sleep(_options.UpdateHeartbeatInterval);
+        }
+        
+        _tcpListener.Stop();
+        
+        _logger.LogInformation("Health Check Tcp Listener ending.");
+    }
+
+    private async Task CheckHealthReportAsync(CancellationToken token)
+    {
+        try
+        {
+            var healthReport = await _healthCheckService.CheckHealthAsync(token);
+            if (healthReport.Status != HealthStatus.Healthy)
+            {
+                _tcpListener.Stop();
+                _logger.LogWarning("Health Report status is {status}.", healthReport.Status.ToString());
+                return;
+            }
+
+            _tcpListener.Start();
+            while (_tcpListener.Server.IsBound && _tcpListener.Pending())
+            {
+                using (var client = await _tcpListener.AcceptTcpClientAsync(token))
+                {
+                    client.Close();
+                }
+
+                _logger.LogTrace("Health Report status is {status}.", healthReport.Status.ToString());
+            }
+
+            _logger.LogTrace("Check Health Report executed.");
+        }
+
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while checking the Health Report.");
+        }
+    }
+}

--- a/SystemDot.Hosting.Diagnostics.HealthChecks/HealthCheckTcpListenerOptions.cs
+++ b/SystemDot.Hosting.Diagnostics.HealthChecks/HealthCheckTcpListenerOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace SystemDot.Hosting.Extensions;
+
+public class HealthCheckTcpListenerOptions
+{
+    private const int DefaultTcpListeningPort = 80;
+
+    public int Port { get; set; } = DefaultTcpListeningPort!;
+
+    public TimeSpan UpdateHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(1);
+}

--- a/SystemDot.Hosting.Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/SystemDot.Hosting.Diagnostics.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace SystemDot.Hosting.Extensions;
+
+public static class HealthChecksBuilderExtensions
+{
+    public static IHealthChecksBuilder AddHealthCheckTcpListener(
+        this IHealthChecksBuilder healthChecksBuilder,
+        Action<HealthCheckTcpListenerOptions>? options = null)
+    {
+        HealthCheckTcpListenerOptions healthCheckTcpListenerOptions = new();
+        options?.Invoke(healthCheckTcpListenerOptions);
+        healthChecksBuilder
+            .Services
+            .AddSingleton(healthCheckTcpListenerOptions)
+            .AddHostedService<HealthCheckTcpListenerBackgroundService>();
+        return healthChecksBuilder;
+    }
+}

--- a/SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj
+++ b/SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj
@@ -8,7 +8,7 @@
         <AssemblyName>SystemDot.Hosting.Diagnostics.HealthChecks</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>SystemDot.Hosting.Diagnostics.HealthChecks</PackageId>
-        <Version>1.0.0-beta</Version>
+        <Version>1.0.0</Version>
         <Authors>James Goodenough, Chris Sampson</Authors>
         <PackageDescription>Health Checks exposed by TCP</PackageDescription>
         <PackageTags>dotnet-worker dotnet-background-service health-checks health-probe tcp kubernetes</PackageTags>

--- a/SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj
+++ b/SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj
@@ -8,7 +8,7 @@
         <AssemblyName>SystemDot.Hosting.Diagnostics.HealthChecks</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>SystemDot.Hosting.Diagnostics.HealthChecks</PackageId>
-        <Version>1.0.0</Version>
+        <Version>1.0.0-beta</Version>
         <Authors>James Goodenough, Chris Sampson</Authors>
         <PackageDescription>Health Checks exposed by TCP</PackageDescription>
         <PackageTags>dotnet-worker dotnet-background-service health-checks health-probe tcp kubernetes</PackageTags>

--- a/SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj
+++ b/SystemDot.Hosting.Diagnostics.HealthChecks/SystemDot.Hosting.Diagnostics.HealthChecks.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>SystemDot.Hosting.Extensions</RootNamespace>
+        <AssemblyName>SystemDot.Hosting.Diagnostics.HealthChecks</AssemblyName>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>SystemDot.Hosting.Diagnostics.HealthChecks</PackageId>
+        <Version>1.0.0</Version>
+        <Authors>James Goodenough, Chris Sampson</Authors>
+        <PackageDescription>Health Checks exposed by TCP</PackageDescription>
+        <PackageTags>dotnet-worker dotnet-background-service health-checks health-probe tcp kubernetes</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Company>SystemDot</Company>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Supports exposing health checks via TCP which can be particularly useful if you want to expose health checks in a non-HTTP workload.